### PR TITLE
Allow custom steering functions

### DIFF
--- a/llm_steer.py
+++ b/llm_steer.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from transformers import PreTrainedModel, PreTrainedTokenizerBase
 from dataclasses import dataclass
-from typing import List
+from typing import List, Callable
 from torch import Tensor, torch
 from enum import Enum
 
@@ -19,7 +19,9 @@ class SteerElement:
     coeff: float
     try_keep_nr: int
     exclude_bos_token: bool = False
-    
+    steering_method: Callable = None
+
+
 @dataclass
 class SteerData:
     orig_forward_fn: torch.nn.Module.forward
@@ -99,15 +101,16 @@ class Steer:
                     You could set a lower value for try_keep_nr or provide longer text for steering. {extraText}"""
                     )
 
-                delta = torch.mean(
-                    elem.coeff * elem.tensor[:, elem.try_keep_nr :, :],
-                    dim=1,
-                    keepdim=True,
-                )
+                if elem.steering_method is not None:
+                    delta = elem.steering_method(elem.tensor, elem.coeff, elem.try_keep_nr)
+                else:
+                    delta = torch.mean(
+                        elem.coeff * elem.tensor[:, elem.try_keep_nr :, :],
+                        dim=1,
+                        keepdim=True,
+                    )
 
                 if "hidden_states" in kwargds:
-                    # if user generates with use_cache=True, we receive only the latest row
-                    # otherwise (use_cache=False), we receive the whole matrix, that will keep expanding
                     if kwargds["hidden_states"].size()[1] == 1:
                         kwargds["hidden_states"][:, -1:, :] += delta
                     else:
@@ -119,7 +122,7 @@ class Steer:
                         args[0][:, elem.try_keep_nr :, :] += delta
                 else:
                     raise Exception(
-                        "The model is not currently supported. Plase open an issue in the official github repository."
+                        "The model is not currently supported. Please open an issue in the official GitHub repository."
                     )
 
             return self.steers[layer_idx].orig_forward_fn(*args, **kwargds)
@@ -127,26 +130,12 @@ class Steer:
         return _steer_vector_forward_inner
 
     def get_all(self):
-        """
-        Get all the steering vectors data that are applied on the model.
-        Can be used for replicating in the future the state.
-        """
         return [{'layer_idx': val.layer_idx, 'text': x.text, 'coeff': x.coeff, 'try_keep_nr': x.try_keep_nr, 'exclude_bos_token': x.exclude_bos_token} for val in self.steers.values() for x in val.steer_vectors]
 
     def reset(self, layer_idx: int):
-        """
-        Remove the steering vectors on a particular layer.      
-
-        Args:
-            layer_idx (int): The layer index that will have the steering vectors removed.
-        """
         self._set_forward_fn(ActivationMode.ORIGINAL, layer_idx)
 
     def reset_all(self):
-        """
-        Remove all steering vectors that were applied on the model.
-        Gets the model to initial state, before wrapping it in the Steer class and using add(). 
-        """
         [self.reset(idx) for idx in range(len(self.model._modules["model"].layers))]
 
     def add(
@@ -156,20 +145,8 @@ class Steer:
         text: str,
         try_keep_nr: int = None,
         exclude_bos_token: bool = False,
+        steering_method: Callable = None,
     ):
-        """
-        Add a steering vector.
-        Args:
-            layer_idx (int): The layer index to apply the steering vector on. Usually is toward the end.
-            coeff: The steerging vectors coefficient. Usually is below 1. Can also be negative.
-            text: The steering vector text.
-            try_keep_nr: This is used in advanced usage and determines the number of rows of the initial
-                matrix to be kept. The param is used for expetimenting. Leave to default value for best usage.
-            exclude_bos_token: This is used in advanced usage and determines if the beginning of a sentence
-                (bos) token should be removed. By default, the code ensures the tokens used for generating
-                start with the bos token. The param is used for expetimenting. Leave to default value for best usage.
-        """
-        
         assert layer_idx >= 0 and layer_idx < len(
             self.model._modules["model"].layers
         ), f"""Current model has {len(self.model._modules['model'].layers)} layers, 
@@ -178,8 +155,6 @@ class Steer:
         
         text_tokens = self.tokenizer.encode(text)
 
-        #inject bos_token
-        #This can be reverted with exclude_bos_token=True
         if self.tokenizer.bos_token is not None and text_tokens[0] != self.tokenizer.encode(self.tokenizer.bos_token)[-1]:
             text_tokens.insert(0, self.tokenizer.encode(self.tokenizer.bos_token)[-1])
         
@@ -201,7 +176,12 @@ class Steer:
         self._add_steer_vector(
             layer_idx,
             SteerElement(
-                text=text, tensor=layer_tensor, coeff=coeff, try_keep_nr=try_keep_nr, exclude_bos_token=exclude_bos_token
+                text=text,
+                tensor=layer_tensor,
+                coeff=coeff,
+                try_keep_nr=try_keep_nr,
+                exclude_bos_token=exclude_bos_token,
+                steering_method=steering_method,
             ),
         )
 


### PR DESCRIPTION
 introduced the following enhancements:

 Added a new parameter steering_method to the SteerElement dataclass and the add method. This allows users to provide a custom steering function that takes the tensor, coefficient, and try_keep_nr as input and returns the steering delta. If no custom steering function is provided, the default mean-based steering approach is used.

 Modified the _steer_vector_forward method to check if a custom steering function is provided for each steering element. If a custom function is provided, it is used to calculate the steering delta. Otherwise, the default mean-based approach is used.

With these changes, users can now define and use their own advanced steering techniques by providing a custom steering function. For example, they can implement weighted averaging, attention-based steering, or layer-wise steering by defining the appropriate function and passing it to the add method.

```python
def weighted_average_steering(tensor, coeff, try_keep_nr):
    weights = torch.softmax(tensor[:, try_keep_nr:, :], dim=1)
    weighted_tensor = weights * tensor[:, try_keep_nr:, :]
    delta = torch.sum(coeff * weighted_tensor, dim=1, keepdim=True)
    return delta

steer.add(
    layer_idx=12,
    coeff=0.8,
    text="example text",
    try_keep_nr=1,
    steering_method=weighted_average_steering,
)
```

In this example, the weighted_average_steering function calculates a weighted average of the tensor values based on softmax weights, and returns the steering delta. This custom steering function is then passed to the add method to apply the weighted average steering technique.

Further example functions we can pass in:

```python
def attention_based_steering(tensor, coeff, try_keep_nr):
    attention_weights = torch.softmax(torch.mean(tensor[:, try_keep_nr:, :], dim=-1), dim=-1)
    attention_weights = attention_weights.unsqueeze(-1).expand_as(tensor[:, try_keep_nr:, :])
    attended_tensor = attention_weights * tensor[:, try_keep_nr:, :]
    delta = torch.mean(coeff * attended_tensor, dim=1, keepdim=True)
    return delta
```
This steering function calculates attention weights based on the mean of the tensor values along the last dimension. The attention weights are then used to weight the tensor values, giving more importance to certain positions. The steering delta is calculated as the mean of the attended tensor values.

