### PR TITLE
Reduce memory overhead when capturing tensors

### DIFF
--- a/llm_steer.py
+++ b/llm_steer.py
@@ -227,7 +227,8 @@ class Steer:
 
     def _capture_tensor(self, layer_idx: int, tokens: Tensor):
         self._set_forward_fn(ActivationMode.CAPTURE, layer_idx)
-        self.model(tokens)
+        with torch.inference_mode():
+            self.model(tokens)
         result = self.captured_tensor
         print(f"captured tensor: {result}")
         return result


### PR DESCRIPTION
My tiny GPU was running out of memory every time I tried to add a steering vector. With this, the additional memory usage is negligible (went from ~2GB to a few MB in my case), and it's running smoothly no matter how many vectors I add. Might be helpful for others working with limited VRAM.